### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,6 @@ android {
         versionName formattedVersionName
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         vectorDrawables.useSupportLibrary true
-        multiDexEnabled true
 
         project.logger.lifecycle("VersionName: $versionName")
         project.logger.lifecycle("VersionCode: $versionCode")
@@ -200,7 +199,6 @@ def lifecycleExtensionVersion = '2.2.0'
 def lifecycleVersion = '2.7.0'
 def appCompatVersion = '1.6.1'
 def androidAnnotationVersion = '1.7.0'
-def multidexVersion = '2.0.1'
 def coroutinesVersion = '1.7.3'
 def recyclerViewVersion = '1.3.2'
 def materialVersion = '1.9.0'
@@ -244,7 +242,6 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:$androidXArchVersion"
     testImplementation "androidx.test:core:$androidXCoreVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
-    testImplementation "org.robolectric:shadows-multidex:$robolectricVersion"
 
     // Android test dependencies
     androidTestImplementation "androidx.test.ext:junit:$androidXJunitVersion"
@@ -252,9 +249,6 @@ dependencies {
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestImplementation "com.google.truth:truth:$truthVersion"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-
-    // MultiDex
-    implementation "androidx.multidex:multidex:$multidexVersion"
 
     // DI
     implementation "io.insert-koin:koin-android:$koinVersion"

--- a/app/src/main/kotlin/com/ivanovsky/passnotes/App.kt
+++ b/app/src/main/kotlin/com/ivanovsky/passnotes/App.kt
@@ -1,7 +1,7 @@
 package com.ivanovsky.passnotes
 
+import android.app.Application
 import android.content.Context
-import androidx.multidex.MultiDexApplication
 import com.ivanovsky.passnotes.data.repository.settings.Settings
 import com.ivanovsky.passnotes.data.repository.settings.SettingsImpl
 import com.ivanovsky.passnotes.domain.LoggerInteractor
@@ -11,7 +11,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
-open class App : MultiDexApplication() {
+open class App : Application() {
 
     open fun configureModuleBuilder(builder: DIModuleBuilder) {
         // implementation should be flavor specific


### PR DESCRIPTION
Since the min SDK is 26, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified application structure by removing multi-dex support, enhancing build efficiency.

- **Bug Fixes**
	- Resolved potential issues related to multi-dexing by transitioning to a standard application class.

- **Chores**
	- Updated dependency management for a more streamlined build process in line with modern Android practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->